### PR TITLE
bug related to files named none generated by galfit

### DIFF
--- a/src/ellipsect/inout/read.py
+++ b/src/ellipsect/inout/read.py
@@ -167,6 +167,20 @@ def ReadGALFITout(ellconf,galhead,galcomps):
 
 
     galcomps = SelectGal(galcomps,ellconf.distmax,ellconf.numcomp)
+    
+    #removes blank files created by galfit
+    if os.path.isfile("none"):
+        print("Blank file none detected")
+        print("Removing...")
+        os.remove("none")
+        print("Removed")
+
+
+    if os.path.isfile("None"):
+        print("Blank file None detected")
+        print("Removing...")
+        os.remove("None")
+        print("Removed")
  
 
     errmsg="file {} does not exist".format(galhead.inputimage)


### PR DESCRIPTION
I added a check that verifies if a file named "None" or "none" exists. In some rare cases this file is generated by GALFIT, and it is interpreted as a FITS file. It indicates that is damaged the file. After checking the program proceeds to delete the file if it exists. 